### PR TITLE
Zip tapisjob_set.exec.sh extract last line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ testreports
 test-output
 
 # Intellij metadata files
+.smarttomcat
 .idea/*
 *.iml
 *.ids

--- a/tapis-jobslib/src/main/java/edu/utexas/tacc/tapis/jobs/stagers/zip/ZipStager.java
+++ b/tapis-jobslib/src/main/java/edu/utexas/tacc/tapis/jobs/stagers/zip/ZipStager.java
@@ -211,6 +211,9 @@ public class ZipStager
             else
               chmod +x "./${APP_EXEC}"
             fi
+            # Sometimes extraneous output precedes the output we are about to generate.
+            # Echo an empty line so we can be sure our output is the final line before we exit.
+            echo
             echo "${APP_EXEC}"
             exit 0
             """;

--- a/tapis-jobslib/src/main/java/edu/utexas/tacc/tapis/jobs/worker/execjob/JobFileManager.java
+++ b/tapis-jobslib/src/main/java/edu/utexas/tacc/tapis/jobs/worker/execjob/JobFileManager.java
@@ -605,7 +605,9 @@ public final class JobFileManager
             String msg = MsgUtils.getMsg("JOBS_ZIP_SETEXEC_ERROR", _job.getUuid(), host, cmd, exitStatus, result);
             throw new TapisException(msg);
         }
-        return result;
+        // We expect the output to be a single line to the app executable to run, but sometimes extraneous text
+        // precedes the output we are looking for. So extract just the final line.
+        return TapisUtils.getLastLine(result);
     }
 
     /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
A simcenter user has an environment where extraneous output is generated when Tapis jobs runs tapisjob_setexec.sh during job staging for a ZIP application. tapisjob_setexec.sh is intended to generate a single line containing the path to the app executable.
Fix is to use an existing utility method to extract only the last line from the output.